### PR TITLE
Fix code scanning alert no. 117: Regular expression injection

### DIFF
--- a/Node-JS-Projects/Advanced/E-Commerce/controllers/ProductController.js
+++ b/Node-JS-Projects/Advanced/E-Commerce/controllers/ProductController.js
@@ -1,6 +1,7 @@
 const Product = require('../models/Product')
 const Category = require('../models/Category');
 const { default: mongoose } = require('mongoose');
+const _ = require('lodash');
 
 exports.createProduct = async (req, res) => {
 
@@ -133,7 +134,8 @@ exports.filterProducts = async (req, res) => {
         }
 
         if (key) {
-            const regex = new RegExp(key, 'i');
+            const safeKey = _.escapeRegExp(key);
+            const regex = new RegExp(safeKey, 'i');
             query.$or = [
                 { name: { $regex: regex } },
                 { description: { $regex: regex } },

--- a/Node-JS-Projects/Advanced/E-Commerce/package.json
+++ b/Node-JS-Projects/Advanced/E-Commerce/package.json
@@ -17,6 +17,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.4.5",
     "nodemailer": "^6.9.14",
-    "nodemon": "^3.1.4"
+    "nodemon": "^3.1.4",
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/Avdhesh-Varshney/WebMasterLog/security/code-scanning/117](https://github.com/Avdhesh-Varshney/WebMasterLog/security/code-scanning/117)

To fix the problem, we need to sanitize the `key` parameter before using it to construct a regular expression. The best way to do this is by using the `_.escapeRegExp` function from the lodash library, which escapes special characters in the string so that they can be used safely in a regular expression.

- Import the lodash library at the top of the file.
- Use `_.escapeRegExp` to sanitize the `key` parameter before constructing the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
